### PR TITLE
flake.nix init

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,90 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    utils.url = "github:numtide/flake-utils";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+  };
+  outputs =
+    {
+      self,
+      nixpkgs,
+      utils,
+      rust-overlay,
+    }:
+    utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ rust-overlay.overlays.default ];
+        };
+        # this is a running release, always pin nightly
+        toolchain = pkgs.rust-bin.nightly.latest.default.override {
+          extensions = [ "rust-src" ];
+        };
+        rustPlatform = pkgs.makeRustPlatform {
+          cargo = toolchain;
+          rustc = toolchain;
+        };
+      in
+      {
+        packages.default = pkgs.stdenv.mkDerivation {
+          pname = "ddnet-rs";
+          version = "0.1.0";
+          src = ./.;
+
+          nativeBuildInputs = with pkgs; [
+            toolchain
+            pkg-config
+          ];
+
+          buildInputs = with pkgs; [
+            ffmpeg
+            vulkan-loader
+            wayland
+            alsa-lib
+            opusfile
+            xorg.libX11
+            xorg.libXcursor
+            xorg.libXi
+
+          ];
+
+          buildPhase = ''
+            export HOME=$(mktemp -d)
+            cargo build --release
+          '';
+
+          installPhase = ''
+            mkdir -p $out/bin
+            cp target/release/ddnet-rs $out/bin/
+          '';
+        };
+
+        devShell =
+          with pkgs;
+          mkShell {
+            buildInputs = [
+
+              xorg.libX11
+              xorg.libXcursor
+              xorg.libXi
+              libz
+
+              ffmpeg
+              vulkan-loader
+              wayland
+              alsa-lib
+              pkg-config
+              toolchain
+              opusfile
+              cargo-watch
+              pre-commit
+              rustPackages.clippy
+            ];
+            RUST_SRC_PATH = "${toolchain}/lib/rustlib/src/rust/library";
+            LD_LIBRARY_PATH = "${pkgs.vulkan-loader}/lib:${pkgs.libxkbcommon}/lib";
+          };
+      }
+    );
+}


### PR DESCRIPTION
this adds a simple flake.nix to use with `nix develop` or `direnv`.

update: fixed all issues below - will require to run non_sandboxed `nix run --option sandbox false`


`nix run` is borked - this issue seems to be nix's way of sandboxing, since we're patching `rust-ffmpeg-sys` it will fail.
related discussion:
https://discourse.nixos.org/t/rust-packaging-issue-unable-to-fetch-git-dependencies-correctly/46547

i dont really wanna create a PR just to update the .gitignore, so i'll keep it in mind if i actually do make a PR with more than 4 loc for that.