### PR TITLE
Add files needed to make macOS Client .app

### DIFF
--- a/macos/client/Info.plist
+++ b/macos/client/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleIconFile</key>
+	<string>DDNet.icns</string>
+	<key>CFBundleExecutable</key>
+	<string>launcher-client.sh</string>
+	<key>CFBundleIdentifier</key>
+	<string>org.DDNet-Rs-Alpha</string>
+	<key>CFBundleName</key>
+	<string>DDNet-Rs</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>macOS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>1.0</string>
+	<key>DTPlatformName</key>
+	<string>macosx</string>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.games</string>
+</dict>
+</plist>

--- a/macos/client/launcher-client.sh
+++ b/macos/client/launcher-client.sh
@@ -1,0 +1,4 @@
+#!/bin/zsh
+
+cd "$(dirname "$0")"
+./ddnet-rs


### PR DESCRIPTION
Adds old version MoltenVK dylib as libvulkan.dylib (ddnet/ddnet-rs#5)
Adds a shell script to cd to the directory so it can find libvulkan.dylib
Add Info.plist that specifies icon and file to execute